### PR TITLE
feat: set additional jwt claims as omniauth params

### DIFF
--- a/lib/omniauth/krystal/initiated_login_middleware.rb
+++ b/lib/omniauth/krystal/initiated_login_middleware.rb
@@ -18,6 +18,8 @@ module OmniAuth
       class AntiReplayTokenAlreadyUsedError < Error
       end
 
+      JWT_RESERVED_CLAIMS = %w[ar exp nbf iss aud jti iat sub].freeze
+
       def initialize(app, options = {})
         @app = app
         @options = options
@@ -65,6 +67,9 @@ module OmniAuth
         # Set the expected omniauth state to the state that we have been given so it
         # thinks the session is trusted as normal.
         env['rack.session']['omniauth.state'] = state
+
+        # Set any additional params that were passed in the state.
+        env['rack.session']['omniauth.params'] = data.reject { |key| JWT_RESERVED_CLAIMS.include?(key) }
 
         @app.call(env)
       end


### PR DESCRIPTION
During an Identity initiated login we want to be able to pass additional params to the client we are trying to login to. The middleware will now set any non-reserved claims in the JWT into the session under the omniauth.params key.